### PR TITLE
Errors reporting fix

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -4,8 +4,8 @@ namespace Macellan\OneSignal\Exceptions;
 
 class CouldNotSendNotification extends \Exception
 {
-    public static function withErrors(array $errors): CouldNotSendNotification
+    public static function withErrors(string $response): CouldNotSendNotification
     {
-        return new static('OneSignal responded with an error: `'.implode(',', $errors).'`');
+        return new static('OneSignal responded with an error: `'.$response.'`');
     }
 }

--- a/src/OneSignalChannel.php
+++ b/src/OneSignalChannel.php
@@ -56,7 +56,7 @@ class OneSignalChannel
         $errors = $result->json('errors');
 
         if (! empty($errors)) {
-            throw CouldNotSendNotification::withErrors($errors);
+            throw CouldNotSendNotification::withErrors($result->body());
         }
 
         return $result;


### PR DESCRIPTION
Changing `CouldNotSendNotification` exception to report response string instead of an array, because implode wouldn't work for multidimensional arrays and some onesignal errors are multidimensional 